### PR TITLE
Fix Crash issue from a different mod

### DIFF
--- a/Tarots/Constellation.lua
+++ b/Tarots/Constellation.lua
@@ -19,9 +19,11 @@ SMODS.Consumable {
     unlocked = true,
     discovered = false,
     in_pool = function(self)
-        for k,v in ipairs(G.jokers.cards) do
-            if v.config.center.Cosmic then
-                return true
+        if G.jokers then
+            for k,v in ipairs(G.jokers.cards) do
+                if v.config.center.Cosmic then
+                    return true
+                end
             end
         end
         return false

--- a/Tarots/Sign.lua
+++ b/Tarots/Sign.lua
@@ -25,9 +25,11 @@ SMODS.Consumable {
     unlocked = true,
     discovered = false,
     in_pool = function(self)
-        for k,v in ipairs(G.jokers.cards) do
-            if v.config.center.Cosmic then
-                return true
+        if G.jokers then
+            for k,v in ipairs(G.jokers.cards) do
+                if v.config.center.Cosmic then
+                    return true
+                end
             end
         end
         return false


### PR DESCRIPTION
Make these tarots check if G.jokers exists first before checking for Cosmic tokens
This prevents a crash from a different mod on launch
I tested this and the in_pool should still be functionally the same